### PR TITLE
chore: remove empty bin field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "author": "shellscape",
   "homepage": "https://github.com/shellscape/webpack-log",
   "bugs": "https://github.com/shellscape/webpack-log/issues",
-  "bin": "",
   "main": "lib/index.js",
   "engines": {
     "node": ">= 8.0.0"


### PR DESCRIPTION
This fixes #2 by removing the empty `bin` field from the package.json as this field is optional.